### PR TITLE
added sh as supported shell

### DIFF
--- a/src/CliPrompt.php
+++ b/src/CliPrompt.php
@@ -75,7 +75,7 @@ class CliPrompt
         if (file_exists('/usr/bin/env')) {
             // handle other OSs with bash/zsh/ksh/csh if available to hide the answer
             $test = "/usr/bin/env %s -c 'echo OK' 2> /dev/null";
-            foreach (array('bash', 'zsh', 'ksh', 'csh') as $sh) {
+            foreach (array('bash', 'zsh', 'ksh', 'csh', 'sh') as $sh) {
                 if ('OK' === rtrim(shell_exec(sprintf($test, $sh)))) {
                     $shell = $sh;
                     break;
@@ -91,7 +91,7 @@ class CliPrompt
                 echo PHP_EOL;
 
                 return $value;
-            }
+            } els
         }
 
         // not able to hide the answer

--- a/src/CliPrompt.php
+++ b/src/CliPrompt.php
@@ -91,7 +91,7 @@ class CliPrompt
                 echo PHP_EOL;
 
                 return $value;
-            } els
+            }
         }
 
         // not able to hide the answer


### PR DESCRIPTION
I don't understand why this was not available before -- sh fully supports read -r!
Tested with `/usr/bin/env sh -c 'stty -echo; read -r mypassword; stty echo; echo $mypassword'` on a system that only has sh(alpine linux minimal).

As composer uses your library and there are images of composer based on alpine linux / other bashless systems, this should be merged to stop people from exposing their private repository passwords.
