### PR TITLE
patch to handle the failure to launch of hiddeninput.exe

### DIFF
--- a/src/CliPrompt.php
+++ b/src/CliPrompt.php
@@ -59,17 +59,20 @@ class CliPrompt
                 $exe = $tmpExe;
             }
 
-            $answer = self::trimAnswer(shell_exec($exe));
+            $scriptOutput = shell_exec($exe);
+            $answer = self::trimAnswer($scriptOutput);
 
             // clean up
             if (isset($tmpExe)) {
                 unlink($tmpExe);
             }
 
-            // output a newline to be on par with the regular prompt()
-            echo PHP_EOL;
-
-            return $answer;
+            if (!is_null($scriptOutput))
+            {
+            	// output a newline to be on par with the regular prompt()
+                echo PHP_EOL;
+                return $answer;
+            }
         }
 
         if (file_exists('/usr/bin/env')) {


### PR DESCRIPTION
In the environment I work in, Windows blocks the running of EXE files which have not been whitelisted, thereby never letting hiddeninput.exe run.

Composer would call hiddeninput.exe which would not run, but the script still proceeded to return an EOL, not allowing me to ever enter a password.

This change checks if NULL was returned from shell_exec() at which point the fallback prompt is used, as was originally intended.